### PR TITLE
Docker image for inference

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ python eval.py --n_sample 100
 ## 3. Pre-trained models
 The pre-trained models and the respective code of each model are shared [here](https://drive.google.com/drive/folders/1nCpr84nKkrs9-aVMET5h8gqFbUYJRPLR?usp=sharing).
 
+You can also use FastGAN to generate images with a pre-packaged Docker image, hosted on the Replicate registry: https://beta.replicate.ai/odegeasslbc/FastGAN
+
 ## 4. Important notes
 1. The provided code is for research use only.
 2. Different model and training configurations are needed on different datasets. You may have to tune the hyper-parameters to get the best results on your own datasets. 

--- a/docker/Dockerfile.cpu
+++ b/docker/Dockerfile.cpu
@@ -1,0 +1,58 @@
+FROM python:3.8-buster
+
+ENV DEBIAN_FRONTEND=noninteractive
+SHELL ["/bin/bash", "-c"]
+
+RUN apt-get update && apt-get install -y unzip
+
+RUN pip install gdown
+RUN mkdir /code
+WORKDIR /code
+
+# Download pre-trained models and remove all but the latest
+# checkpoint for each model to save space
+
+RUN gdown -O trial_shell.zip "https://drive.google.com/uc?id=1plZ72wC1u8jX12PD3FaMzV5Z06XUuLj-" && \
+        unzip trial_shell.zip && \
+        rm trial_shell.zip && \
+        rm trial_shell/models/{all_10000.pth,all_20000.pth,10000.pth,20000.pth,30000.pth} && \
+        mv trial_shell/models/all_30000.pth trial_shell/models/30000.pth
+RUN gdown -O trial_skull.zip "https://drive.google.com/uc?id=1MVHSnf3Z42ZcRPk-29qXfjYgS1CKPuhm" && \
+        unzip trial_skull.zip && \
+        rm trial_skull.zip && \
+        rm trial_skull/models/{30000.pth,40000.pth}
+RUN gdown -O trial_dog.zip "https://drive.google.com/uc?id=1iHdCRXG_Y7Z_fTwFPMHAnHYGcmNpaHVn" && \
+        unzip trial_dog.zip && \
+        rm trial_dog.zip && \
+        rm trial_dog/models/{40000.pth,60000.pth}
+RUN gdown -O trial_panda.zip "https://drive.google.com/uc?id=1p1oRxpljgc2_M4NfaRrxmfNeC8RWAw8V" && \
+        unzip trial_panda.zip && \
+        rm trial_panda.zip && \
+        rm trial_panda/models/30000.pth
+RUN gdown -O good_ffhq_full_512.zip  "https://drive.google.com/uc?id=1oBxHC16Vpm-_9xWkuM43MHGQMMVijyJA" && \
+        unzip good_ffhq_full_512.zip && \
+        rm good_ffhq_full_512.zip && \
+        mv good_ffhq_full_512/models/all_100000.pth good_ffhq_full_512/models/100000.pth
+RUN gdown -O good_art_1k_512.zip "https://drive.google.com/uc?id=1RHTmh0dWM0Mg-S8_maKv5Up3m6wuwY08" && \
+        unzip good_art_1k_512.zip && \
+        rm good_art_1k_512.zip && \
+        mv good_art_1k_512/models/all_50000.pth good_art_1k_512/models/50000.pth
+
+RUN pip install \
+        tqdm==4.56.0 \
+        scipy==1.6.0 \
+        scikit-image==0.18.1 \
+        ipdb==0.13.4 \
+        pandas==1.2.1 \
+        lmdb==1.0.0 \
+        opencv-python==4.5.1.48 \
+        easing-functions==1.0.4 \
+        torch==1.7.0 \
+        torchvision==0.8.0
+
+# Make the models work on cpu
+RUN for model in *; do sed -i "s/torch.device('cuda:%d'%(args.cuda))/torch.device('cpu')/" $model/eval.py; done
+
+COPY docker/infer.sh infer.sh
+RUN chmod +x infer.sh
+ENTRYPOINT ["./infer.sh"]

--- a/docker/Dockerfile.gpu
+++ b/docker/Dockerfile.gpu
@@ -1,0 +1,52 @@
+FROM docker.io/pytorch/pytorch:1.7.0-cuda11.0-cudnn8-devel
+
+SHELL ["/bin/bash", "-c"]
+
+RUN apt-get update && apt-get install -y unzip
+
+RUN pip install gdown
+RUN mkdir /code
+WORKDIR /code
+
+# Download pre-trained models and remove all but the latest
+# checkpoint for each model to save space
+
+RUN gdown -O trial_shell.zip "https://drive.google.com/uc?id=1plZ72wC1u8jX12PD3FaMzV5Z06XUuLj-" && \
+        unzip trial_shell.zip && \
+        rm trial_shell.zip && \
+        rm trial_shell/models/{all_10000.pth,all_20000.pth,10000.pth,20000.pth,30000.pth} && \
+        mv trial_shell/models/all_30000.pth trial_shell/models/30000.pth
+RUN gdown -O trial_skull.zip "https://drive.google.com/uc?id=1MVHSnf3Z42ZcRPk-29qXfjYgS1CKPuhm" && \
+        unzip trial_skull.zip && \
+        rm trial_skull.zip && \
+        rm trial_skull/models/{30000.pth,40000.pth}
+RUN gdown -O trial_dog.zip "https://drive.google.com/uc?id=1iHdCRXG_Y7Z_fTwFPMHAnHYGcmNpaHVn" && \
+        unzip trial_dog.zip && \
+        rm trial_dog.zip && \
+        rm trial_dog/models/{40000.pth,60000.pth}
+RUN gdown -O trial_panda.zip "https://drive.google.com/uc?id=1p1oRxpljgc2_M4NfaRrxmfNeC8RWAw8V" && \
+        unzip trial_panda.zip && \
+        rm trial_panda.zip && \
+        rm trial_panda/models/30000.pth
+RUN gdown -O good_ffhq_full_512.zip  "https://drive.google.com/uc?id=1oBxHC16Vpm-_9xWkuM43MHGQMMVijyJA" && \
+        unzip good_ffhq_full_512.zip && \
+        rm good_ffhq_full_512.zip && \
+        mv good_ffhq_full_512/models/all_100000.pth good_ffhq_full_512/models/100000.pth
+RUN gdown -O good_art_1k_512.zip "https://drive.google.com/uc?id=1RHTmh0dWM0Mg-S8_maKv5Up3m6wuwY08" && \
+        unzip good_art_1k_512.zip && \
+        rm good_art_1k_512.zip && \
+        mv good_art_1k_512/models/all_50000.pth good_art_1k_512/models/50000.pth
+
+RUN pip install \
+        tqdm==4.56.0 \
+        scipy==1.6.0 \
+        scikit-image==0.18.1 \
+        ipdb==0.13.4 \
+        pandas==1.2.1 \
+        lmdb==1.0.0 \
+        opencv-python==4.5.1.48 \
+        easing-functions==1.0.4
+
+COPY docker/infer.sh infer.sh
+RUN chmod +x infer.sh
+ENTRYPOINT ["./infer.sh"]

--- a/docker/build-and-push.sh
+++ b/docker/build-and-push.sh
@@ -1,0 +1,41 @@
+#!/bin/bash -eux
+
+# Run this script from the repo's root folder
+#
+# $ ./docker/build-and-push.sh
+
+# 1. Build Docker images for CPU and GPU
+
+image="us-docker.pkg.dev/replicate/odegeasslbc/fastgan"
+cpu_tag="$image:cpu"
+gpu_tag="$image:gpu"
+
+docker build -f docker/Dockerfile.cpu --tag "$cpu_tag" .
+docker build -f docker/Dockerfile.gpu --tag "$gpu_tag" .
+
+# 2. Test Docker images
+
+test_output_folder=/tmp/test-chromagan/output
+
+docker run -it --rm \
+       -v $test_output_folder/cpu:/outputs \
+       $cpu_tag \
+       art --n_sample=20
+
+[ -f $test_output_folder/cpu/0.png ] || exit 1
+[ -f $test_output_folder/cpu/9.png ] || exit 1
+
+docker run --gpus all -it --rm \
+       -v $test_output_folder/gpu:/outputs \
+       $gpu_tag \
+       art --n_sample=20
+
+[ -f $test_output_folder/gpu/0.png ] || exit 1
+[ -f $test_output_folder/gpu/9.png ] || exit 1
+
+sudo rm -rf "$test_output_folder"
+
+# 3. Push Docker images
+
+docker push $cpu_tag
+docker push $gpu_tag

--- a/docker/infer.sh
+++ b/docker/infer.sh
@@ -1,0 +1,61 @@
+#!/bin/bash -eu
+
+# The eval.py scripts in the various pre-trained model folders differ slightly.
+# * The model iteration is different
+# * The range() statement that selects the checkpoint iteration sometimes includes +1 on end_iter, sometimes not
+# * The image size differs
+# * The batch size differs
+
+case $1 in
+
+    shell)
+        model="trial_shell"
+        start_iter=3
+        end_iter=4
+        size=1024
+        batch_size=8
+        ;;
+
+    skull)
+        model="trial_skull"
+        start_iter=5
+        end_iter=6
+        size=1024
+        batch_size=8
+        ;;
+
+    dog)
+        model="trial_dog"
+        start_iter=8
+        end_iter=8
+        size=256
+        batch_size=8
+        ;;
+
+    art)
+        model="good_art_1k_512"
+        start_iter=5
+        end_iter=5
+        size=512
+        batch_size=12
+        ;;
+
+    face)
+        model="good_ffhq_full_512"
+        start_iter=10
+        end_iter=10
+        size=512
+        batch_size=16
+        ;;
+
+    *)
+        echo "Unknown model '$1', valid options are: 'art', 'face', 'shell', 'skull', 'dog'."
+        exit 1
+        ;;
+esac
+
+shift 1
+
+cd $model
+python eval.py --start_iter=$start_iter --end_iter=$end_iter --im_size=$size --size=$size --batch=$batch_size $@
+mv eval_${start_iter}0000/img/* /outputs/


### PR DESCRIPTION
This pull request includes a Dockerfile that packages FastGAN in a reproducible Docker image. I've pushed the image to the Replicate Docker registry and included a link in the README: https://beta.replicate.ai/odegeasslbc/FastGAN

For the Docker image I wrote a small `infer.sh` script that switches between model types (`art`, `face`, `dog`, etc.). There's a little hack in `Dockerfile.cpu` that makes the pre-trained models work on CPU as well.

We are working to make Replicate a registry of machine learning models that can be easily reproduced. With Docker the models can be run "forever", without having to worry about missing dependencies. The website design is still a work in progress, so it might look a little rough around the edges.